### PR TITLE
Utilise file instead of stderr for integration tests

### DIFF
--- a/pkg/integration/result/result.go
+++ b/pkg/integration/result/result.go
@@ -1,0 +1,102 @@
+package result
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// On windows the pty package is failing to obtain stderr text when a test fails,
+// so this is our workaround: when a test fails, it writes the result to a file,
+// and then the test runner reads the file and checks the result
+
+const PathEnvVar = "LAZYGIT_INTEGRATION_TEST_RESULT_PATH"
+
+type IntegrationTestResult struct {
+	Success bool
+	Message string
+}
+
+func LogFailure(message string) error {
+	return writeResult(failure(message))
+}
+
+func LogSuccess() error {
+	return writeResult(success())
+}
+
+func failure(message string) IntegrationTestResult {
+	return IntegrationTestResult{Success: false, Message: message}
+}
+
+func success() IntegrationTestResult {
+	return IntegrationTestResult{Success: true}
+}
+
+func writeResult(result IntegrationTestResult) error {
+	resultPath := os.Getenv(PathEnvVar)
+	if resultPath == "" {
+		return fmt.Errorf("Environment variable %s not set", PathEnvVar)
+	}
+
+	file, err := os.Create(resultPath)
+	if err != nil {
+		return fmt.Errorf("Error creating file: %w", err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	err = encoder.Encode(result)
+	if err != nil {
+		return fmt.Errorf("Error encoding JSON: %w", err)
+	}
+
+	return nil
+}
+
+// Reads the result file stored by the lazygit test, and deletes the file
+func ReadResult(resultPath string) (IntegrationTestResult, error) {
+	file, err := os.Open(resultPath)
+	if err != nil {
+		return IntegrationTestResult{}, fmt.Errorf("Error creating file: %w", err)
+	}
+
+	decoder := json.NewDecoder(file)
+	var result IntegrationTestResult
+	err = decoder.Decode(&result)
+	if err != nil {
+		file.Close()
+		return IntegrationTestResult{}, fmt.Errorf("Error decoding JSON: %w", err)
+	}
+
+	file.Close()
+	_ = os.Remove(resultPath)
+
+	return result, nil
+}
+
+func SetResultPathEnvVar(cmd *exec.Cmd, resultPath string) {
+	cmd.Env = append(
+		cmd.Env,
+		fmt.Sprintf("%s=%s", PathEnvVar, resultPath),
+	)
+}
+
+func GetResultPath() string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("lazygit_result_%s.json", generateRandomString(10)))
+}
+
+func generateRandomString(length int) string {
+	buffer := make([]byte, length)
+	_, err := rand.Read(buffer)
+	if err != nil {
+		panic(fmt.Sprintf("Could not generate random string: %s", err))
+	}
+
+	randomString := base64.URLEncoding.EncodeToString(buffer)
+	return randomString[:length]
+}

--- a/pkg/integration/tests/commit/commit.go
+++ b/pkg/integration/tests/commit/commit.go
@@ -27,7 +27,7 @@ var Commit = NewIntegrationTest(NewIntegrationTestArgs{
 			PressPrimaryAction(). // stage file
 			Lines(
 				Contains("A  myfile").IsSelected(),
-				Contains("?? myfile2"),
+				Contains("?? myfile23"),
 			).
 			SelectNextItem().
 			PressPrimaryAction(). // stage other file


### PR DESCRIPTION
Windows for some reason is not properly making use of stderr so instead we're going to write our result to a file explicitly

- **PR Description**

- **Please check if the PR fulfills these requirements**

* [ ] Cheatsheets are up-to-date (run `go generate ./...`)
* [ ] Code has been formatted (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#code-formatting))
* [ ] Tests have been added/updated (see [here](https://github.com/jesseduffield/lazygit/blob/master/pkg/integration/README.md) for the integration test guide)
* [ ] Text is internationalised (see [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#internationalisation))
* [ ] Docs (specifically `docs/Config.md`) have been updated if necessary
* [ ] You've read through your own file changes for silly mistakes etc

<!--
Be sure to name your PR with an imperative e.g. 'Add worktrees view'
see https://github.com/jesseduffield/lazygit/releases/tag/v0.40.0 for examples
-->
